### PR TITLE
Fix iframe caching issue of Custom components

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/IkiProcessBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/IkiProcessBuilder.jsx
@@ -46,7 +46,8 @@ const widgetReferrerURL = document.referrer.substring(
   document.referrer.length - 1,
 );
 // const widgetReferrerURL = 'http://localhost:3000';
-const iframeEmptyURL = `${widgetReferrerURL}/widget/diagram/builder`;
+const timestamp = new Date().getTime().toString();
+const iframeEmptyURL = `${widgetReferrerURL}/widget/diagram/builder?v=1&process_diagram_times=${timestamp}`;
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -137,6 +138,7 @@ class IkiProcessBuilder extends React.PureComponent {
       ).src = widgetUrl;
       const tempIframe = `<iframe
                         id="ikiprocessdiagram-widget-${this.props.component.id}"
+                        name="process-diagram-${timestamp}"
                         src="${widgetUrl}"
                         title="IkiProcessDiagram Component"
                         className="ikiprocessdiagram-widget"
@@ -229,6 +231,7 @@ class IkiProcessBuilder extends React.PureComponent {
         ).src = widgetUrl;
         const tempIframe = `<iframe
                             id="ikiprocessdiagram-widget-${this.props.component.id}"
+                            name="process-diagram-${timestamp}"
                             src="${widgetUrl}"
                             title="IkiProcessDiagram Component"
                             className="ikiprocessdiagram-widget"
@@ -258,6 +261,7 @@ class IkiProcessBuilder extends React.PureComponent {
         ).src = widgetUrl;
         const tempIframe = `<iframe
                             id="ikiprocessdiagram-widget-${this.props.component.id}"
+                            name="process-diagram-${timestamp}"
                             src="${widgetUrl}"
                             title="IkiProcessDiagram Component"
                             className="ikiprocessdiagram-widget"
@@ -327,6 +331,7 @@ class IkiProcessBuilder extends React.PureComponent {
                 // widgetUrl.searchParams.set('data', infoStringCompresed);
                 const tempIframe = `<iframe
                           id="ikiprocessdiagram-widget-${this.props.component.id}"
+                          name="process-diagram-${timestamp}"
                           src="${widgetUrl}"
                           title="IkiProcessDiagram Component"
                           className="ikiprocessdiagram-widget"
@@ -461,7 +466,7 @@ class IkiProcessBuilder extends React.PureComponent {
     if (markdownSource) {
       html = markdownSource;
     } else {
-      html = `<iframe id="ikiprocessdiagram-widget-${this.props.component.id}" src="${iframeEmptyURL}?mode=edit&scid=${this.props.component.id}" title="IkiProcessDiagram Component" class="ikiprocessdiagram-iframe"></iframe>`;
+      html = `<iframe id="ikiprocessdiagram-widget-${this.props.component.id}" name="process-diagram-${timestamp}" src="${iframeEmptyURL}?mode=edit&scid=${this.props.component.id}" title="IkiProcessDiagram Component" class="ikiprocessdiagram-iframe"></iframe>`;
     }
     return <SafeMarkdown source={hasError ? MARKDOWN_ERROR_MESSAGE : html} />;
   }
@@ -472,7 +477,7 @@ class IkiProcessBuilder extends React.PureComponent {
     if (markdownSource) {
       html = markdownSource;
     } else {
-      html = `<iframe id="ikiprocessdiagram-widget-${this.props.component.id}" src="${iframeEmptyURL}?mode=edit&scid=${this.props.component.id}" title="IkiProcessDiagram Component" class="ikiprocessdiagram-iframe"></iframe>`;
+      html = `<iframe id="ikiprocessdiagram-widget-${this.props.component.id}" name="process-diagram-${timestamp}" src="${iframeEmptyURL}?mode=edit&scid=${this.props.component.id}" title="IkiProcessDiagram Component" class="ikiprocessdiagram-iframe"></iframe>`;
     }
     return <SafeMarkdown source={hasError ? MARKDOWN_ERROR_MESSAGE : html} />;
   }

--- a/superset-frontend/src/dashboard/components/gridComponents/IkiRunPipeline.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/IkiRunPipeline.jsx
@@ -41,7 +41,8 @@ import {
 // const dashURL = 'https://dev-ui.ikigailabs.io';
 // const dashURL = 'http://localhost:3000';
 const dashURL = document.referrer.substring(0, document.referrer.length - 1);
-const iframeEmptyURL = `${dashURL}/widget/pipeline/run`;
+const timestamp = new Date().getTime().toString();
+const iframeEmptyURL = `${dashURL}/widget/pipeline/run?v=1&run_flow_times=${timestamp}`;
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -262,6 +263,7 @@ class IkiRunPipeline extends React.PureComponent {
                 () => {
                   const tempIframe = `<iframe
                     id="ikirunpipeline-widget-${this.props.component.id}"
+                    name="run-flow-${timestamp}"
                     src="${widgetUrl}"
                     title="IkiRunPipeline Component"
                     className="ikirunpipeline-widget"
@@ -315,6 +317,7 @@ class IkiRunPipeline extends React.PureComponent {
               () => {
                 const tempIframe = `<iframe
                     id="ikirunpipeline-widget-${this.props.component.id}"
+                    name="run-flow-${timestamp}"
                     src="${widgetUrl}"
                     title="IkiRunPipeline Component"
                     className="ikirunpipeline-widget"
@@ -445,7 +448,8 @@ class IkiRunPipeline extends React.PureComponent {
     } else {
       iframe = `<iframe
                   id="ikirunpipeline-widget-${this.props.component.id}"
-                  src="${dashURL}/widget/pipeline/run"
+                  name="run-flow-${timestamp}"
+                  src="${dashURL}/widget/pipeline/run?v=1&run_flow_times=${timestamp}"
                   title="IkiRunPipeline Component"
                   className="ikirunpipeline-widget"
                   style="height: 100%;"
@@ -462,7 +466,8 @@ class IkiRunPipeline extends React.PureComponent {
     } else {
       iframe = `<iframe
                   id="ikirunpipeline-widget-${this.props.component.id}"
-                  src="${dashURL}/widget/pipeline/run"
+                  name="run-flow-${timestamp}"
+                  src="${dashURL}/widget/pipeline/run?v=1&run_flow_times=${timestamp}"
                   title="IkiRunPipeline Component"
                   className="ikirunpipeline-widget"
                   style="height:100%;"

--- a/superset-frontend/src/dashboard/components/gridComponents/IkiTable.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/IkiTable.jsx
@@ -41,7 +41,8 @@ import {
 // const dashURL = 'https://dev-ui.ikigailabs.io';
 // const dashURL = 'http://localhost:3000';
 const dashURL = document.referrer.substring(0, document.referrer.length - 1);
-const iframeEmptyURL = `${dashURL}/widget/dataset/table?mode=edit`;
+const timestamp = new Date().getTime().toString();
+const iframeEmptyURL = `${dashURL}/widget/dataset/table?v=1&editable_dataset_times=${timestamp}&mode=edit`;
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -264,6 +265,7 @@ class IkiTable extends React.PureComponent {
                 () => {
                   const tempIframe = `<iframe
                     id="ikitable-widget-${this.props.component.id}"
+                    name="editable-dataset-${timestamp}"
                     src="${widgetUrl}"
                     title="IkiTable Component"
                     className="ikitable-widget"
@@ -285,8 +287,6 @@ class IkiTable extends React.PureComponent {
           } else if (
             messageObject.info === 'widget-to-superset/sending-datasets-ids'
           ) {
-            console.log('widget-to-superset/sending-datasets-ids');
-            console.log('messageObject', messageObject);
             if (
               document.getElementById(
                 `ikitable-widget-${this.props.component.id}`,
@@ -297,23 +297,15 @@ class IkiTable extends React.PureComponent {
                   `ikitable-widget-${this.props.component.id}`,
                 ).src,
               );
-              console.log('widgetUrl', widgetUrl);
               // const widgetUrlQuery = new URLSearchParams(widgetUrl);
               const widgetUrlQueryTblType = widgetUrl.searchParams.get(
                 'table_type',
               );
-              const widgetUrlQueryTblMode = widgetUrl.searchParams.get('mode');
+              // const widgetUrlQueryTblMode = widgetUrl.searchParams.get('mode');
               const widgetUrlQueryProjectId = widgetUrl.searchParams.get(
                 'project_id',
               );
-              console.log(
-                'widgetUrlQueryTblType',
-                widgetUrlQueryTblType,
-                'widgetUrlQueryTblMode',
-                widgetUrlQueryTblMode,
-              );
               if (!widgetUrlQueryTblType) {
-                console.log('table type not set!');
                 widgetUrl.searchParams.set('mode', 'preview');
                 const tableType = messageData.tableType
                   ? messageData.tableType
@@ -341,7 +333,6 @@ class IkiTable extends React.PureComponent {
                   );
                 }
                 // widgetUrl.search = widgetUrlQuery.toString();
-                console.log('last step - widgetUrl', widgetUrl);
                 this.setState(
                   {
                     iframeUrl: widgetUrl,
@@ -350,6 +341,7 @@ class IkiTable extends React.PureComponent {
                     // console.log('widgetUrl...', widgetUrl);
                     const tempIframe = `<iframe
                         id="ikitable-widget-${this.props.component.id}"
+                        name="editable-dataset-${timestamp}"
                         src="${widgetUrl}"
                         title="IkiTable Component"
                         className="ikitable-widget"
@@ -476,7 +468,8 @@ class IkiTable extends React.PureComponent {
     } else {
       iframe = `<iframe
                   id="ikitable-widget-${this.props.component.id}"
-                  src="${dashURL}/widget/dataset/table?mode=edit"
+                  name="editable-dataset-${timestamp}"
+                  src="${dashURL}/widget/dataset/table?v=1&editable_dataset_times=${timestamp}&mode=edit"
                   title="IkiTable Component"
                   className="ikitable-widget"
                   style="height:100%;"
@@ -493,7 +486,8 @@ class IkiTable extends React.PureComponent {
     } else {
       iframe = `<iframe
                   id="ikitable-widget-${this.props.component.id}"
-                  src="${dashURL}/widget/dataset/table?mode=edit"
+                  name="editable-dataset-${timestamp}"
+                  src="${dashURL}/widget/dataset/table?v=1&editable_dataset_times=${timestamp}&mode=edit"
                   title="IkiTable Component"
                   className="ikitable-widget"
                   style="height:100%;"

--- a/superset-frontend/src/dashboard/components/gridComponents/new/NewIkiRunPipeline.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/new/NewIkiRunPipeline.jsx
@@ -28,7 +28,7 @@ export default function DraggableNewDivider() {
     <DraggableNewComponent
       id={NEW_IKI_RUN_PIPELINE_ID}
       type={IKI_RUN_PIPELINE_TYPE}
-      label={t('Run Pipeline')}
+      label={t('Run Flow')}
       className="fa fa-bolt"
     />
   );

--- a/superset-frontend/src/dashboard/components/gridComponents/new/NewIkiTable.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/new/NewIkiTable.jsx
@@ -28,7 +28,7 @@ export default function DraggableNewDivider() {
     <DraggableNewComponent
       id={NEW_IKI_TABLE_ID}
       type={IKI_TABLE_TYPE}
-      label={t('Table')}
+      label={t('Editable Dataset')}
       className="fa fa-table"
     />
   );


### PR DESCRIPTION
Fix iframe caching issue for Custom components (Run Flow, Editable Dataset and Process Diagram)

### SUMMARY
Timestamp has been added to URL as a parameter as well as name attribute of iframe html element in order to always force rendering of latest custom component iframe

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
