### PR TITLE
Time Grain Error Fix (Squashed Commit)

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -705,6 +705,11 @@ BACKUP_COUNT = 30
 #     pass
 QUERY_LOGGER = None
 
+# Uncomment below to view SQL Query in logs
+# def log_sql_statements(database, query, schema, user, client, security_manager): 
+#     logger.info("Ikigai SQL Query :" + str(query)) 
+# QUERY_LOGGER = log_sql_statements
+
 # Set this API key to enable Mapbox visualizations
 MAPBOX_API_KEY = os.environ.get("MAPBOX_API_KEY", "")
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -138,6 +138,8 @@ logger = logging.getLogger(__name__)
 ADVANCED_DATA_TYPES = config["ADVANCED_DATA_TYPES"]
 VIRTUAL_TABLE_ALIAS = "virtual_table"
 
+IKIGAI_TIMESTAMP_SUFFIX = "__IKIGAITS"
+
 # a non-exhaustive set of additive metrics
 ADDITIVE_METRIC_TYPES = {
     "count",
@@ -354,7 +356,10 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
         :param template_processor: template processor
         :return: A TimeExpression object wrapped in a Label if supported by db
         """
-        label = label or utils.DTTM_ALIAS
+        if label:
+            label = f"{label}{IKIGAI_TIMESTAMP_SUFFIX}"
+        else:
+            label = utils.DTTM_ALIAS
 
         pdf = self.python_date_format
         is_epoch = pdf in ("epoch_s", "epoch_ms")
@@ -1890,6 +1895,11 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 if len(df.columns) > len(labels_expected):
                     df = df.iloc[:, 0 : len(labels_expected)]
                 df.columns = labels_expected
+
+                for column in df.columns:
+                    if column.endswith(IKIGAI_TIMESTAMP_SUFFIX):
+                        df.rename(columns={column: column[:len(column)-len(IKIGAI_TIMESTAMP_SUFFIX)]}, inplace=True)
+
             return df
 
         try:


### PR DESCRIPTION
time series error fix (#61)

* Show time-series again

* Generic axes enabled, query logging enabled

* logging type escalation

* Testing SQL printing in logs

* Testing SQL printing in logs

* Testing SQL printing in logs

* Superset alias fix

* Superset alias fix 2

* Testing date_trunc query generation

* Testing date_trunc query generation

* Testing date_trunc query generation

* Testing date_trunc query generation

* feeling lucky

* print labels_expected

* edit labels_expected

* another attempt

* another attempt 2

* print

* print df type

* rename column

* rename column

* rename column

* rename column

* rename column

* rename column

* rename column

* rename column

* rename column

* rename column

* trying something

* custom label method

* removing log messages

* cosmetic changes

* cosmetic changes

* cosmetic changes

Cosmetic changes

query logger fix

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
