### PR TITLE
[IPLT-5462] Charts reloading issue after run-flow-btn, superset part

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/IkiRunPipeline.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/IkiRunPipeline.jsx
@@ -67,6 +67,7 @@ const propTypes = {
   depth: PropTypes.number.isRequired,
   editMode: PropTypes.bool.isRequired,
   ikigaiOrigin: PropTypes.string,
+  dashboardLayout: PropTypes.object,
 
   // from redux
   logEvent: PropTypes.func.isRequired,
@@ -312,6 +313,7 @@ class IkiRunPipeline extends React.PureComponent {
             'widget-to-superset/sending-charts-to-refresh'
           ) {
             const { selectedCharts } = messageData;
+            console.log('selectedCharts', selectedCharts);
             this.refreshCharts(selectedCharts);
           }
         }
@@ -320,9 +322,33 @@ class IkiRunPipeline extends React.PureComponent {
   }
 
   refreshCharts(selectedCharts) {
-    selectedCharts.forEach(selectedChart => {
-      this.refreshChart(selectedChart.id, this.state.dashboardId, false);
-    });
+    const layoutElements = this.props.dashboardLayout?.present
+      ? this.props.dashboardLayout?.present
+      : null;
+    if (selectedCharts) {
+      selectedCharts.forEach(selectedChart => {
+        if (selectedChart?.refresh_id) {
+          this.refreshChart(
+            selectedChart?.refresh_id,
+            this.state.dashboardId,
+            false,
+          );
+        } else {
+          let findChartEle = null;
+          if (layoutElements) {
+            Object.keys(layoutElements).forEach(ele => {
+              if (layoutElements[ele].meta?.sliceName === selectedChart.name) {
+                findChartEle = ele;
+              }
+            });
+          }
+          console.log('findChartEle', findChartEle);
+          if (findChartEle) {
+            this.refreshChart(findChartEle, this.state.dashboardId, false);
+          }
+        }
+      });
+    }
   }
 
   setEditor(editor) {
@@ -563,6 +589,7 @@ class IkiRunPipeline extends React.PureComponent {
       onResizeStop,
       handleComponentDrop,
       editMode,
+      dashboardLayout,
     } = this.props;
 
     // inherit the size of parent columns
@@ -651,6 +678,7 @@ function mapStateToProps(state) {
   return {
     undoLength: state.dashboardLayout.past.length,
     redoLength: state.dashboardLayout.future.length,
+    dashboardLayout: state.dashboardLayout,
   };
 }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
